### PR TITLE
Bugfixes to VIM estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -651,3 +651,4 @@ cor_coxph/output/janssen_pooled_realADCP/D29IncludeNotMolecConfirmedstart1/ylims
 cor_coxph/output/janssen_pooled_realPsV/D29IncludeNotMolecConfirmed/coxph_slopes.Rdata
 cor_coxph/output/janssen_pooled_realPsV/D29IncludeNotMolecConfirmedstart1/coxph_slopes.Rdata
 cor_surrogates/output/*.csv
+cor_surrogates/code/test/*

--- a/cor_surrogates/code/cor_surrogates_setup.R
+++ b/cor_surrogates/code/cor_surrogates_setup.R
@@ -71,16 +71,16 @@ if (study_name %in% c("COVE", "MockCOVE")) {
   # baseline risk factors
   briskfactors <- c("risk_score", "HighRiskInd", "MinorityInd")
   briskfactors_correction <- "Y ~ x + X$risk_score + X$HighRiskInd + X$MinorityInd"
-  
-  individualMarkers <- c("Day57bindSpike", 
-                         "Day57bindRBD", 
-                         "Day57pseudoneutid50", 
-                         "Day57pseudoneutid80", 
+
+  individualMarkers <- c("Day57bindSpike",
+                         "Day57bindRBD",
+                         "Day57pseudoneutid50",
+                         "Day57pseudoneutid80",
                          "Day57liveneutmn50",
-                         "Day29bindSpike", 
-                         "Day29bindRBD", 
+                         "Day29bindSpike",
+                         "Day29bindRBD",
                          "Day29pseudoneutid50",
-                         "Day29pseudoneutid80", 
+                         "Day29pseudoneutid80",
                          "Day29liveneutmn50")
 
   # markers of interest
@@ -94,7 +94,7 @@ if (study_name %in% c("COVE", "MockCOVE")) {
                   "Delta57overBpseudoneutid80_2fold", "Delta57overBpseudoneutid80_4fold",
                   "Day57liveneutmn50", #"Delta57overBliveneutmn50",
                   "Delta57overBliveneutmn50_2fold", "Delta57overBliveneutmn50_4fold",
-                  
+
                   "Day29bindSpike", #"Delta29overBbindSpike",
                   "Delta29overBbindSpike_2fold", "Delta29overBbindSpike_4fold",
                   "Day29bindRBD", #"Delta29overBbindRBD",
@@ -435,11 +435,11 @@ if (study_name %in% c("COVE", "MockCOVE")) {
                     "2_bAbSpike_D57", "3_bAbRBD_D57", "4_pnabID50_D57",
                     "5_pnabID80_D57", "6_lnabMN50_D57", "7_bAb_pnabID50_D57", "8_bAb_pnabID80_D57", "9_bAb_lnabMN50_D57",
                     "10_bAb_combScores_D57", "11_allMarkers_D57", "12_allMarkers_combScores_D57",
-                    
+
                     "13_bAbSpike_D29", "14_bAbRBD_D29", "15_pnabID50_D29",
                     "16_pnabID80_D29", "17_lnabMN50_D29", "18_bAb_pnabID50_D29", "19_bAb_pnabID80_D29", "20_bAb_lnabMN50_D29",
                     "21_bAb_combScores_D29", "22_allMarkers_D29", "23_allMarkers_combScores_D29",
-                    
+
                     "24_bAbSpike_D29_D57", "25_bAbRBD_D29_D57", "26_pnabID50_D29_D57",
                     "27_pnabID80_D29_D57", "28_lnabMN50_D29_D57", "29_bAb_pnabID50_D29_D57", "30_bAb_pnabID80_D29_D57", "31_bAb_lnabMN50_D29_D57",
                     "32_bAb_combScores_D29_D57", "33_allMarkers_D29_D57", "34_allMarkers_combScores_D29_D57")
@@ -447,13 +447,13 @@ if (study_name %in% c("COVE", "MockCOVE")) {
   # set up a matrix of all
   varset_matrix <- rbind(varset_baselineRiskFactors,
                          varset_bAbSpike_D57, varset_bAbRBD_D57, varset_pnabID50_D57,
-                         varset_pnabID80_D57, varset_lnabMN50_D57, varset_bAb_pnabID50_D57, varset_bAb_pnabID80_D57, varset_bAb_lnabMN50_D57, 
+                         varset_pnabID80_D57, varset_lnabMN50_D57, varset_bAb_pnabID50_D57, varset_bAb_pnabID80_D57, varset_bAb_lnabMN50_D57,
                          varset_bAb_combScores_D57, varset_allMarkers_D57, varset_allMarkers_combScores_D57,
-                         
+
                          varset_bAbSpike_D29, varset_bAbRBD_D29, varset_pnabID50_D29,
                          varset_pnabID80_D29, varset_lnabMN50_D29, varset_bAb_pnabID50_D29, varset_bAb_pnabID80_D29, varset_bAb_lnabMN50_D29,
                          varset_bAb_combScores_D29, varset_allMarkers_D29, varset_allMarkers_combScores_D29,
-                         
+
                          varset_bAbSpike_D29_D57, varset_bAbRBD_D29_D57, varset_pnabID50_D29_D57,
                          varset_pnabID80_D29_D57, varset_lnabMN50_D29_D57, varset_bAb_pnabID50_D29_D57, varset_bAb_pnabID80_D29_D57, varset_bAb_lnabMN50_D29_D57,
                          varset_bAb_combScores_D29_D57, varset_allMarkers_D29_D57, varset_allMarkers_combScores_D29_D57)
@@ -571,6 +571,11 @@ all_non_cc_treatment <- Z_plus_weights %>%
 # put them back together
 phase_1_data_treatmentDAT <- dplyr::bind_rows(all_cc_treatment, all_non_cc_treatment) %>%
   select(-Trt)
+# indicator of observed in phase 2
+C <- (phase_1_data_treatmentDAT$Ptid %in% treatmentDAT$Ptid)
+# all outcomes; first come outcomes in phase 2 sample, then the remainder
+full_y <- phase_1_data_treatmentDAT %>%
+  pull(!!endpoint)
 
 if (study_name %in% c("COVE", "MockCOVE")) {
   Z_treatmentDAT <- phase_1_data_treatmentDAT %>%
@@ -583,8 +588,6 @@ if (study_name %in% c("COVE", "MockCOVE")) {
   all_ipw_weights_treatment <- phase_1_data_treatmentDAT %>%
     pull(wt.D210)
 }
-
-C <- (phase_1_data_treatmentDAT$Ptid %in% treatmentDAT$Ptid)
 
 # set up outer folds for cv variable importance; do stratified sampling
 V_outer <- 5

--- a/cor_surrogates/code/get_vimp.R
+++ b/cor_surrogates/code/get_vimp.R
@@ -33,9 +33,7 @@ set.seed(20210216)
 seeds <- round(runif(10, 1000, 10000))
 # set up
 all_estimates <- NULL
-full_y <- dat.ph1 %>%
-  pull(!!endpoint)
-X <- dat.ph1 %>%
+X <- phase_1_data_treatmentDAT %>%
   select(!!ptidvar, !!briskfactors) %>%
   left_join(dat.ph2 %>%
     select(!!ptidvar, all_of(markers)), by = ptidvar

--- a/cor_surrogates/code/get_vimp.R
+++ b/cor_surrogates/code/get_vimp.R
@@ -61,6 +61,10 @@ sample_splitting_folds <- lapply(list_of_indices, function(l) {
   set.seed(seeds[l])
   these_ss_folds <- vimp::make_folds(unique(cf_folds[[l]]), V = 2)
 })
+# flip the sample splitting folds for the baseline comparison so that we're comparing the correct splits
+sample_splitting_folds_baseline <- lapply(sample_splitting_folds, function(l) {
+    (-1) * l + 3
+})
 
 # get the naive predictor (outcome mean within each fold)
 naive_fits <- lapply(list_of_indices, function(l) {
@@ -95,7 +99,7 @@ for (i in seq_len(nrow(varset_matrix))) {
     vim_lst <- lapply(list_of_indices, function(l) {
       get_cv_vim(seed = seeds[l], Y = full_y, X = X, full_fit = full_fits[[l]], reduced_fit = naive_fits[[l]],
                  index = this_s, type = "auc", scale = "identity", cross_fitting_folds = cf_folds[[l]],
-                 sample_splitting_folds = sample_splitting_folds[[l]], V = vim_V,
+                 sample_splitting_folds = sample_splitting_folds_baseline[[l]], V = vim_V,
                  C = C, Z = c("Y", paste0("X", which(briskfactors %in% names(X)))), sl_lib = sl_lib,
                  ipc_est_type = "ipw", ipc_weights = all_ipw_weights_treatment, baseline = TRUE,
                  use_ensemble = use_ensemble_sl)

--- a/cor_surrogates/code/utils.R
+++ b/cor_surrogates/code/utils.R
@@ -323,12 +323,18 @@ get_cv_vim <- function(seed = NULL, Y = NULL, X = NULL, full_fit = NULL, reduced
     cvsl_obj = NULL, preds = reduced_cv_fit, sample_splitting = sample_splitting, sample_splitting_folds = switch(as.numeric(sample_splitting) + 1, rep(2, V), sample_splitting_folds),
     full = FALSE, cross_fitting_folds = cross_fitting_folds
   )
+  # add on CV folds for the people only sampled into phase 1
+  if (is.null(Z)) {
+    cf_folds <- cross_fitting_folds
+  } else {
+    cf_folds <- c(cross_fitting_folds, sample(seq_len(length(unique(cross_fitting_folds))), length(C) - length(cross_fitting_folds), replace = TRUE))
+  }
   set.seed(seed)
   # estimate variable importance
   est_vim <- vimp::cv_vim(Y = Y, X = X, cross_fitted_f1 = full_cv_preds,
                           cross_fitted_f2 = reduced_cv_preds, indx = index,
                           delta = 0, V = V, run_regression = FALSE,
-                          sample_splitting = sample_splitting, cross_fitting_folds = cross_fitting_folds,
+                          sample_splitting = sample_splitting, cross_fitting_folds = cf_folds,
                           sample_splitting_folds = sample_splitting_folds,
                           type = type, scale = scale,
                           SL.library = sl_library, ipc_est_type = ipc_est_type,


### PR DESCRIPTION
Fixed several bugs in VIM estimation:
- Use the correctly ordered rows for the phase 1 data in VIM estimation (for the full outcome, for Z)
- Use extra folds for phase 1 data (for EIF estimation)
- Update `get_cv_vim` to use the correct object when `use_ensemble = TRUE`
- Allow `sample_splitting = FALSE` (for debugging)
- Update `pool_cv_vim` to use point estimates of predictiveness for VIM point estimates (rather than averaging the VIM point estimates) for pooling across random starts